### PR TITLE
chore: Enable multi-architecture Docker image builds and pushes using…

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Image (Multi-Arch)
 
 on:
   push:
@@ -22,14 +22,26 @@ jobs:
         chmod +x gradlew
         ./gradlew bootJar
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - name: Log in to Docker Hub
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Get Short SHA
+      id: slug
+      run: echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_OUTPUT
+
     - name: Build and Push Docker image
-      run: |
-        cd server
-        docker build -t ${{ secrets.DOCKER_USERNAME }}/boardbuddy-server:${{ github.sha }} .
-        docker push ${{ secrets.DOCKER_USERNAME }}/boardbuddy-server:${{ github.sha }}
+      uses: docker/build-push-action@v4
+      with:
+        context: ./server
+        push: true
+        tags: ${{ secrets.DOCKER_USERNAME }}/boardbuddy-server:${{ steps.slug.outputs.sha8 }}
+        platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
… Buildx and QEMU, and update image tagging to use a short SHA.

- linux/arm64
- sha code 7글자