### PR TITLE
feat: Implement guest management functionality

### DIFF
--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/api/GuestController.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/api/GuestController.java
@@ -1,0 +1,64 @@
+package com.boardbuddies.boardbuddiesserver.api;
+
+import com.boardbuddies.boardbuddiesserver.config.CurrentUser;
+import com.boardbuddies.boardbuddiesserver.dto.common.ApiResponse;
+import com.boardbuddies.boardbuddiesserver.dto.guest.GuestCreateRequest;
+import com.boardbuddies.boardbuddiesserver.dto.guest.GuestResponse;
+import com.boardbuddies.boardbuddiesserver.service.GuestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/guests")
+@RequiredArgsConstructor
+public class GuestController {
+
+    private final GuestService guestService;
+
+    /**
+     * 게스트 등록
+     * POST /api/guests
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<GuestResponse>> createGuest(
+            @CurrentUser Long userId,
+            @RequestBody GuestCreateRequest request) {
+
+        GuestResponse response = guestService.createGuest(userId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(201, "게스트 등록 완료", response));
+    }
+
+    /**
+     * 게스트 조회
+     * GET /api/guests/{guestId}
+     */
+    @GetMapping("/{guestId}")
+    public ResponseEntity<ApiResponse<GuestResponse>> getGuest(
+            @CurrentUser Long userId,
+            @PathVariable Long guestId) {
+
+        GuestResponse response = guestService.getGuest(userId, guestId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(200, "게스트 조회 완료", response));
+    }
+
+    /**
+     * 본인이 등록한 게스트 목록 조회
+     * GET /api/guests
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<java.util.List<GuestResponse>>> getMyGuests(
+            @CurrentUser Long userId) {
+
+        java.util.List<GuestResponse> response = guestService.getMyGuests(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(200, "게스트 목록 조회 완료", response));
+    }
+}
+

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/api/UserController.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/api/UserController.java
@@ -82,11 +82,12 @@ public class UserController {
                         ApiResponse.error(400, "종료일은 시작일보다 빠를 수 없습니다."));
             }
 
-            reservations = reservationRepository.findAllByUserAndDateBetweenOrderByCreatedAtDesc(user, startDate,
+            // 일반 예약만 조회 (게스트 예약 제외)
+            reservations = reservationRepository.findAllByUserAndGuestIsNullAndDateBetweenOrderByCreatedAtDesc(user, startDate,
                     endDate);
         } else {
-            // 기본 조회 (전체 또는 최근 N건 - 여기서는 전체로 구현하되 필요시 제한 가능)
-            reservations = reservationRepository.findAllByUserOrderByCreatedAtDesc(user);
+            // 일반 예약만 조회 (게스트 예약 제외)
+            reservations = reservationRepository.findAllByUserAndGuestIsNullOrderByCreatedAtDesc(user);
         }
 
         List<ReservationResponse> response = reservations.stream()

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/domain/Guest.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/domain/Guest.java
@@ -1,0 +1,59 @@
+package com.boardbuddies.boardbuddiesserver.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 게스트 엔티티
+ * 부원이 등록한 게스트 정보를 저장합니다.
+ */
+@Entity
+@Table(name = "guests")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Guest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 게스트 이름
+     */
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    /**
+     * 게스트 전화번호
+     */
+    @Column(nullable = false, length = 20)
+    private String phoneNumber;
+
+    /**
+     * 게스트 학교/소속
+     */
+    @Column(length = 100)
+    private String school;
+
+    /**
+     * 게스트를 등록한 부원 (User)
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User registeredBy;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}
+

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/domain/Reservation.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/domain/Reservation.java
@@ -26,6 +26,13 @@ public class Reservation {
     @JoinColumn(name = "crew_id", nullable = false)
     private Crew crew;
 
+    /**
+     * 게스트 예약인 경우 게스트 정보 (일반 예약인 경우 null)
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guest_id")
+    private Guest guest;
+
     @Column(nullable = false)
     private LocalDate date;
 

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/guest/GuestCreateRequest.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/guest/GuestCreateRequest.java
@@ -1,0 +1,29 @@
+package com.boardbuddies.boardbuddiesserver.dto.guest;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuestCreateRequest {
+
+    /**
+     * 게스트 이름
+     */
+    private String name;
+
+    /**
+     * 게스트 전화번호
+     */
+    private String phoneNumber;
+
+    /**
+     * 게스트 학교/소속
+     */
+    private String school;
+}
+

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/guest/GuestResponse.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/guest/GuestResponse.java
@@ -1,0 +1,32 @@
+package com.boardbuddies.boardbuddiesserver.dto.guest;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuestResponse {
+
+    private Long id;
+    private String name;
+    private String phoneNumber;
+    private String school;
+    private LocalDateTime createdAt;
+    
+    /**
+     * 등록한 부원 ID
+     */
+    private Long registeredById;
+    
+    /**
+     * 등록한 부원 이름
+     */
+    private String registeredByName;
+}
+

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/reservation/ReservationListResponse.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/reservation/ReservationListResponse.java
@@ -24,7 +24,18 @@ public class ReservationListResponse {
     @AllArgsConstructor
     public static class UserSummary {
         private Long userId;
+        /**
+         * 예약자 이름 (게스트 예약인 경우 게스트 이름, 일반 예약인 경우 부원 이름)
+         */
         private String name;
         private Role role;
+        /**
+         * 게스트 예약인 경우 게스트 ID (일반 예약인 경우 null)
+         */
+        private Long guestId;
+        /**
+         * 게스트 예약인 경우 예약한 부원 이름 (일반 예약인 경우 null)
+         */
+        private String registeredByName;
     }
 }

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/reservation/ReservationMemberResponse.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/reservation/ReservationMemberResponse.java
@@ -10,9 +10,24 @@ public class ReservationMemberResponse {
     @JsonProperty("user_id")
     private Long userId;
 
+    /**
+     * 예약자 이름 (게스트 예약인 경우 게스트 이름, 일반 예약인 경우 부원 이름)
+     */
     @JsonProperty("name")
     private String name;
 
     @JsonProperty("profile_image_url")
     private String profileImageUrl;
+
+    /**
+     * 게스트 예약인 경우 게스트 ID (일반 예약인 경우 null)
+     */
+    @JsonProperty("guest_id")
+    private Long guestId;
+
+    /**
+     * 게스트 예약인 경우 예약한 부원 이름 (일반 예약인 경우 null)
+     */
+    @JsonProperty("registered_by_name")
+    private String registeredByName;
 }

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/reservation/ReservationRequest.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/dto/reservation/ReservationRequest.java
@@ -19,4 +19,10 @@ public class ReservationRequest {
     private Long crewId;
 
     private List<LocalDate> dates;
+
+    /**
+     * 게스트 예약인 경우 게스트 ID (일반 예약인 경우 null)
+     */
+    @JsonProperty("guest_id")
+    private Long guestId;
 }

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/repository/GuestRepository.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/repository/GuestRepository.java
@@ -1,0 +1,38 @@
+package com.boardbuddies.boardbuddiesserver.repository;
+
+import com.boardbuddies.boardbuddiesserver.domain.Guest;
+import com.boardbuddies.boardbuddiesserver.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 게스트 Repository
+ */
+@Repository
+public interface GuestRepository extends JpaRepository<Guest, Long> {
+
+    /**
+     * 등록한 부원으로 게스트 목록 조회
+     */
+    List<Guest> findAllByRegisteredByOrderByCreatedAtDesc(User registeredBy);
+
+    /**
+     * 등록한 부원으로 게스트 목록 조회 (Fetch Join으로 N+1 문제 방지)
+     */
+    @Query("SELECT g FROM Guest g " +
+            "LEFT JOIN FETCH g.registeredBy " +
+            "WHERE g.registeredBy = :registeredBy " +
+            "ORDER BY g.createdAt DESC")
+    List<Guest> findAllByRegisteredByOrderByCreatedAtDescWithFetch(@Param("registeredBy") User registeredBy);
+
+    /**
+     * 등록한 부원과 ID로 게스트 조회
+     */
+    Optional<Guest> findByIdAndRegisteredBy(Long id, User registeredBy);
+}
+

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/repository/ReservationRepository.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package com.boardbuddies.boardbuddiesserver.repository;
 
 import com.boardbuddies.boardbuddiesserver.domain.Reservation;
 import com.boardbuddies.boardbuddiesserver.domain.Crew;
+import com.boardbuddies.boardbuddiesserver.domain.Guest;
 import com.boardbuddies.boardbuddiesserver.domain.User;
 import com.boardbuddies.boardbuddiesserver.dto.crew.DailyReservationCount;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,13 +21,64 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         List<Reservation> findAllByUserAndDateBetweenOrderByCreatedAtDesc(User user, LocalDate startDate,
                         LocalDate endDate);
 
+        /**
+         * 일반 예약만 조회 (게스트 예약 제외) - 전체
+         * guest IS NULL을 먼저 체크하여 게스트 예약을 빠르게 제외
+         */
+        @Query("SELECT r FROM Reservation r " +
+                "WHERE r.guest IS NULL AND r.user = :user " +
+                "ORDER BY r.createdAt DESC")
+        List<Reservation> findAllByUserAndGuestIsNullOrderByCreatedAtDesc(@Param("user") User user);
+
+        /**
+         * 일반 예약만 조회 (게스트 예약 제외) - 날짜 범위
+         * guest IS NULL을 먼저 체크하여 게스트 예약을 빠르게 제외
+         */
+        @Query("SELECT r FROM Reservation r " +
+                "WHERE r.guest IS NULL AND r.user = :user " +
+                "AND r.date BETWEEN :startDate AND :endDate " +
+                "ORDER BY r.createdAt DESC")
+        List<Reservation> findAllByUserAndGuestIsNullAndDateBetweenOrderByCreatedAtDesc(
+                @Param("user") User user,
+                @Param("startDate") LocalDate startDate,
+                @Param("endDate") LocalDate endDate);
+
+        /**
+         * 일반 예약만 조회 (게스트 예약 제외) - 특정 날짜
+         * guest IS NULL을 먼저 체크하여 게스트 예약을 빠르게 제외
+         */
+        @Query("SELECT r FROM Reservation r " +
+                "WHERE r.guest IS NULL AND r.user = :user AND r.crew = :crew " +
+                "AND r.date = :date AND r.status <> :status")
+        Optional<Reservation> findByUserAndCrewAndDateAndStatusNotAndGuestIsNull(
+                @Param("user") User user,
+                @Param("crew") Crew crew,
+                @Param("date") LocalDate date,
+                @Param("status") String status);
+
         Long countByCrewAndDateAndStatusNot(Crew crew, LocalDate date, String status);
 
         List<Reservation> findByCrewAndDateAndStatusOrderByCreatedAtAsc(Crew crew, LocalDate date, String status);
 
         Optional<Reservation> findByUserAndCrewAndDateAndStatusNot(User user, Crew crew, LocalDate date, String status);
 
+        /**
+         * 게스트 예약 조회 (취소되지 않은 것)
+         */
+        Optional<Reservation> findByGuestAndCrewAndDateAndStatusNot(Guest guest, Crew crew, LocalDate date, String status);
+
         List<Reservation> findByCrewAndDateAndStatusNot(Crew crew, LocalDate date, String status);
+
+        /**
+         * 크루와 날짜로 예약 조회 (User, Guest Fetch Join으로 N+1 문제 방지)
+         */
+        @Query("SELECT r FROM Reservation r " +
+                "LEFT JOIN FETCH r.user " +
+                "LEFT JOIN FETCH r.guest " +
+                "LEFT JOIN FETCH r.guest.registeredBy " +
+                "WHERE r.crew = :crew AND r.date = :date AND r.status <> :status " +
+                "ORDER BY r.createdAt ASC")
+        List<Reservation> findByCrewAndDateAndStatusNotWithFetch(Crew crew, LocalDate date, @Param("status") String status);
 
         List<Reservation> findByCrewAndStatus(Crew crew, String status);
 
@@ -34,6 +86,17 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
                         String status);
 
         List<Reservation> findAllByCrewAndDateAndStatusNotOrderByCreatedAtAsc(Crew crew, LocalDate date, String status);
+
+        /**
+         * 크루와 날짜로 예약 조회 (User, Guest Fetch Join으로 N+1 문제 방지) - 정렬 포함
+         */
+        @Query("SELECT r FROM Reservation r " +
+                "LEFT JOIN FETCH r.user " +
+                "LEFT JOIN FETCH r.guest " +
+                "LEFT JOIN FETCH r.guest.registeredBy " +
+                "WHERE r.crew = :crew AND r.date = :date AND r.status <> :status " +
+                "ORDER BY r.createdAt ASC")
+        List<Reservation> findAllByCrewAndDateAndStatusNotOrderByCreatedAtAscWithFetch(Crew crew, LocalDate date, @Param("status") String status);
 
         @Query("SELECT new com.boardbuddies.boardbuddiesserver.dto.crew.DailyReservationCount(r.date, COUNT(r)) " +
                         "FROM Reservation r " +
@@ -49,7 +112,32 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         List<Reservation> findAllByCrewAndUserAndDateBetweenAndStatusNot(Crew crew, User user, LocalDate startDate,
                         LocalDate endDate, String status);
 
+        /**
+         * 일반 예약만 조회 (게스트 예약 제외) - 크루, 사용자, 날짜 범위
+         * guest IS NULL을 먼저 체크하여 게스트 예약을 빠르게 제외
+         */
+        @Query("SELECT r FROM Reservation r " +
+                "WHERE r.guest IS NULL AND r.crew = :crew AND r.user = :user " +
+                "AND r.date BETWEEN :startDate AND :endDate AND r.status <> :status")
+        List<Reservation> findAllByCrewAndUserAndDateBetweenAndStatusNotAndGuestIsNull(
+                @Param("crew") Crew crew,
+                @Param("user") User user,
+                @Param("startDate") LocalDate startDate,
+                @Param("endDate") LocalDate endDate,
+                @Param("status") String status);
+
         Long countByUserAndCrewAndStatus(User user, Crew crew, String status);
+
+        /**
+         * 일반 예약만 카운트 (게스트 예약 제외)
+         * guest IS NULL을 먼저 체크하여 게스트 예약을 빠르게 제외
+         */
+        @Query("SELECT COUNT(r) FROM Reservation r " +
+                "WHERE r.guest IS NULL AND r.user = :user AND r.crew = :crew AND r.status = :status")
+        Long countByUserAndCrewAndStatusAndGuestIsNull(
+                @Param("user") User user,
+                @Param("crew") Crew crew,
+                @Param("status") String status);
 
         Long countByCrewAndDateAndStatusAndCreatedAtBefore(Crew crew, LocalDate date, String status,
                         java.time.LocalDateTime createdAt);

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/service/CrewService.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/service/CrewService.java
@@ -695,8 +695,8 @@ public class CrewService {
         List<CrewMyMonthlyReservationResponse> myReservations = getMyMonthlyReservations(userId, crewId, startDate,
                 endDate);
 
-        // 2. 이용 횟수 (확정된 예약 수)
-        int usageCount = reservationRepository.countByUserAndCrewAndStatus(user, crew, "confirmed").intValue();
+        // 2. 이용 횟수 (확정된 일반 예약 수만, 게스트 예약 제외)
+        int usageCount = reservationRepository.countByUserAndCrewAndStatusAndGuestIsNull(user, crew, "confirmed").intValue();
 
         return com.boardbuddies.boardbuddiesserver.dto.crew.MyCalendarResponse.builder()
                 .myReservations(myReservations)
@@ -722,8 +722,8 @@ public class CrewService {
         Crew crew = crewRepository.findById(crewId)
                 .orElseThrow(() -> new RuntimeException("해당 크루를 찾을 수 없습니다."));
 
-        // 내 예약 정보 조회
-        List<Reservation> reservations = reservationRepository.findAllByCrewAndUserAndDateBetweenAndStatusNot(
+        // 일반 예약만 조회 (게스트 예약 제외)
+        List<Reservation> reservations = reservationRepository.findAllByCrewAndUserAndDateBetweenAndStatusNotAndGuestIsNull(
                 crew, user, startDate, endDate, "CANCELLED");
 
         return reservations.stream()

--- a/server/src/main/java/com/boardbuddies/boardbuddiesserver/service/GuestService.java
+++ b/server/src/main/java/com/boardbuddies/boardbuddiesserver/service/GuestService.java
@@ -1,0 +1,104 @@
+package com.boardbuddies.boardbuddiesserver.service;
+
+import com.boardbuddies.boardbuddiesserver.domain.Guest;
+import com.boardbuddies.boardbuddiesserver.domain.User;
+import com.boardbuddies.boardbuddiesserver.dto.guest.GuestCreateRequest;
+import com.boardbuddies.boardbuddiesserver.dto.guest.GuestResponse;
+import com.boardbuddies.boardbuddiesserver.repository.GuestRepository;
+import com.boardbuddies.boardbuddiesserver.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GuestService {
+
+    private final GuestRepository guestRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 게스트 등록
+     * 부원이 게스트 정보를 등록합니다.
+     */
+    @Transactional
+    public GuestResponse createGuest(Long userId, GuestCreateRequest request) {
+        // 1. 사용자 조회 및 권한 검증
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        if (user.getCrew() == null) {
+            throw new RuntimeException("크루에 소속된 회원만 게스트를 등록할 수 있습니다.");
+        }
+
+        // 2. 게스트 생성
+        Guest guest = Guest.builder()
+                .name(request.getName())
+                .phoneNumber(request.getPhoneNumber())
+                .school(request.getSchool())
+                .registeredBy(user)
+                .build();
+
+        guest = guestRepository.save(guest);
+
+        // 3. 응답 생성
+        return GuestResponse.builder()
+                .id(guest.getId())
+                .name(guest.getName())
+                .phoneNumber(guest.getPhoneNumber())
+                .school(guest.getSchool())
+                .createdAt(guest.getCreatedAt())
+                .registeredById(user.getId())
+                .registeredByName(user.getName())
+                .build();
+    }
+
+    /**
+     * 게스트 조회 (본인이 등록한 게스트)
+     */
+    @Transactional(readOnly = true)
+    public GuestResponse getGuest(Long userId, Long guestId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Guest guest = guestRepository.findByIdAndRegisteredBy(guestId, user)
+                .orElseThrow(() -> new RuntimeException("게스트를 찾을 수 없습니다."));
+
+        return GuestResponse.builder()
+                .id(guest.getId())
+                .name(guest.getName())
+                .phoneNumber(guest.getPhoneNumber())
+                .school(guest.getSchool())
+                .createdAt(guest.getCreatedAt())
+                .registeredById(guest.getRegisteredBy().getId())
+                .registeredByName(guest.getRegisteredBy().getName())
+                .build();
+    }
+
+    /**
+     * 본인이 등록한 게스트 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public java.util.List<GuestResponse> getMyGuests(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        // Fetch Join으로 N+1 문제 방지
+        java.util.List<Guest> guests = guestRepository.findAllByRegisteredByOrderByCreatedAtDescWithFetch(user);
+
+        return guests.stream()
+                .map(guest -> GuestResponse.builder()
+                        .id(guest.getId())
+                        .name(guest.getName())
+                        .phoneNumber(guest.getPhoneNumber())
+                        .school(guest.getSchool())
+                        .createdAt(guest.getCreatedAt())
+                        .registeredById(guest.getRegisteredBy().getId())
+                        .registeredByName(guest.getRegisteredBy().getName())
+                        .build())
+                .toList();
+    }
+}
+


### PR DESCRIPTION
## 게스트 관련 API 추가
- 게스트 등록
- 게스트 예약 생성: 예약자 정보도 함께 저장됨
- 특정 게스트 조회
- 게스트 목록 조회
- 내 예약 내역, 나의 달력에서는 게스트의 예약 정보를 조회하지 않음.
- 크루 달력에 게스트의 예약 내역과 함께 예약자 정보도 함께 뜨게 함.
- 포스트맨 API 문서에서 <게스트> 폴더 확인 요망
- 게스트 예약 취소: `guest_id` 포함하여 예약 취소 요청 시 해당 게스트의 예약 내역이 삭제됨.

게스트 삭제 기능은 추후 구현 예정
- 게스트 관리 방법에 대한 기획 구체화 필요 @ijake-16 

related to #15