### PR TITLE
feat: Expose PostgreSQL port in Docker Compose

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -26,6 +26,8 @@ services:
   db:
     image: postgres:15-alpine
     container_name: boardbuddy-db
+    ports:
+      - "5432:5432"
     environment:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=${DB_USERNAME}


### PR DESCRIPTION
- Added port mapping for PostgreSQL service to allow external access on port 5432.
- psql 포트포워딩 설정 추가